### PR TITLE
Add Cargo.toml field to crates.io publishing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,8 +2,18 @@
 name = "serde_libconfig"
 version = "0.0.1"
 edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+authors = ["Bastian Schmidt <basti@schmidt-electronics.de>"]
+categories = ["encoding", "parser-implementations", "no-std"]
+description = "A libconfig serialization file format"
+keywords = ["libconfig", "serde", "serialization"]
+license = "Apache-2.0"
+repository = "https://github.com/bastian-src/serde_libconfig"
+readme = "README.md"
+include = [
+    "**/*.rs",
+    "Cargo.toml",
+    "LICENSE",
+]
 
 [dependencies]
 anyhow = "1.0.82"


### PR DESCRIPTION
According to [rust docs - publishing](https://doc.rust-lang.org/cargo/reference/publishing.html)